### PR TITLE
Improved back button behaviour and fixed #46

### DIFF
--- a/app/src/main/java/de/tap/easy_xkcd/Activities/MainActivity.java
+++ b/app/src/main/java/de/tap/easy_xkcd/Activities/MainActivity.java
@@ -744,7 +744,10 @@ public class MainActivity extends AppCompatActivity {
                 zoomReset = ((OfflineFragment) fragmentManager.findFragmentByTag(BROWSER_TAG)).zoomReset();
             }
             if (!zoomReset) {
-                showOverview();
+                if (!SearchResultsActivity.isOpen)
+                    showOverview();
+                else
+                    super.onBackPressed();
             }
         } else if (mCurrentFragment == R.id.nav_favorites) {
             if (!FavoritesFragment.zoomReset()) {

--- a/app/src/main/java/de/tap/easy_xkcd/Activities/SearchResultsActivity.java
+++ b/app/src/main/java/de/tap/easy_xkcd/Activities/SearchResultsActivity.java
@@ -601,4 +601,20 @@ public class SearchResultsActivity extends AppCompatActivity {
         MainActivity.fromSearch = true;
         super.onBackPressed();
     }
+
+
+    public static boolean isOpen;
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        isOpen=true;
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        isOpen=false;
+    }
+
 }

--- a/app/src/main/java/de/tap/easy_xkcd/utils/Comic.java
+++ b/app/src/main/java/de/tap/easy_xkcd/utils/Comic.java
@@ -91,6 +91,8 @@ public class Comic {
                 break;
             case 847: result[1] = "Eärendil will patrol the walls of night only until the sun reaches red giant stage, engulfing the Morning Star on his brow. Light and high beauty are passing things as well.";
                 break;
+            case 1379: result[1] = "The good news is that according to the latest IPCC report, if we enact aggressive emissions limits now, we could hold the warming to 2°C. That's only HALF an ice age unit, which is probably no big deal.";
+                break;
             case 1037: result[2] = "http://www.explainxkcd.com/wiki/images/f/ff/umwelt_the_void.jpg";
                 break;
             case 1608: result[2] = "http://www.explainxkcd.com/wiki/images/4/41/hoverboard.png";


### PR DESCRIPTION
When the user opens a comic via the SearchResultsActivity and then presses the back button, the application would usually first open the overview mode before going back to the SearchResultsActivity.
I tried to improve this by making the application check if the user had previously opened a SearchResultsActivity.
The back button should now either open the overview mode or navigate back to your search results depending on whether you just performed a search or not.
I also fixed issue #46.
