### PR TITLE
Issue/148 emoji alt text

### DIFF
--- a/app/src/main/java/de/tap/easy_xkcd/fragments/comics/ComicFragment.java
+++ b/app/src/main/java/de/tap/easy_xkcd/fragments/comics/ComicFragment.java
@@ -218,7 +218,7 @@ public abstract class ComicFragment extends Fragment {
             RealmComic comic = getRealmComic(position); //TODO check if comic is null
 
             try {
-                tvAlt.setText(comic.getAltText());
+                tvAlt.setText(Html.fromHtml(comic.getAltText()));
                 tvTitle.setText(Html.fromHtml(comic.getTitle()));
                 pvComic.setTransitionName("im" + comic.getComicNumber());
                 tvTitle.setTransitionName(String.valueOf(comic.getComicNumber()));


### PR DESCRIPTION
### Fix
Add `Html.fromHtml` method to setting `tvAlt` `TextView` text in `ComicFragment` so that emojis are rendered correctly in both classic and pop-up alt text views to close https://github.com/tom-anders/Easy_xkcd/issues/148.

![emojigate](https://user-images.githubusercontent.com/3827611/57734590-7184a580-765f-11e9-8aae-d4026de255aa.png)

#### Note
A similar technique is used on the `tvTitle` view in `ComicFragment` just below these changes.

### Test
Since the alt text from the comic in question, https://xkcd.com/2131/, has changed, I replaced the changes from this pull request with the following snippet for testing purposes.

```java
String alt = "&#129340&#129340&#129340&#129340&#129340&#129340&#129340&#129340";
tvAlt.setText(Html.fromHtml(alt));
```