### PR TITLE
Issue/156 encoding alt text

### DIFF
--- a/app/src/main/java/de/tap/easy_xkcd/database/RealmComic.java
+++ b/app/src/main/java/de/tap/easy_xkcd/database/RealmComic.java
@@ -48,6 +48,7 @@ import okio.Okio;
 import timber.log.Timber;
 
 import static de.tap.easy_xkcd.utils.JsonParser.getJSONFromUrl;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class RealmComic extends RealmObject {
 
@@ -184,7 +185,7 @@ public class RealmComic extends RealmObject {
                             getStringArray(R.array.large_comics_urls)[Arrays.binarySearch(context.getResources().getIntArray(R.array.large_comics), comicNumber)];
                 }
 
-                altText = new String(json.getString("alt").getBytes("ISO-8859-1"), "UTF-8");
+                altText = new String(json.getString("alt").getBytes(UTF_8));
                 transcript = json.getString("transcript");
 
                 // some image and title fixes

--- a/app/src/main/java/de/tap/easy_xkcd/database/RealmComic.java
+++ b/app/src/main/java/de/tap/easy_xkcd/database/RealmComic.java
@@ -215,7 +215,7 @@ public class RealmComic extends RealmObject {
                 if(Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) { //https doesn't work on KitKat and lower for some reason...
                     url = url.replaceAll("https", "http");
                 }
-            } catch (JSONException | UnsupportedEncodingException e) {
+            } catch (JSONException e) {
                 Timber.wtf(e);
             }
         } else {

--- a/app/src/main/java/de/tap/easy_xkcd/database/RealmComic.java
+++ b/app/src/main/java/de/tap/easy_xkcd/database/RealmComic.java
@@ -171,7 +171,7 @@ public class RealmComic extends RealmObject {
             url = "http://i.imgur.com/p0eKxKs.png";
         } else if (json.length() != 0) {
             try {
-                title = new String(json.getString("title").getBytes("ISO-8859-1"), "UTF-8");
+                title = new String(json.getString("title").getBytes(UTF_8));
                 if (isInteractiveComic(comicNumber, context)) {
                     title += " (interactive)";
                 }


### PR DESCRIPTION
### Fix
Update the `getBytes` method parameter from `"ISO-8859-1"` to `UTF_8` in `RealmComic` so that text is rendered correctly in both classic and pop-up alt text views to close #156.  The `getBytes` method for the title text was also updated to match the alt text.  See the screenshots below for illustration.

![156](https://user-images.githubusercontent.com/3827611/61164792-aed9a800-a4d5-11e9-9c7e-8b5e804ee5af.png)

### Test
1. Open comic 2175.
2. Long-press comic image.
3. Notice alt text contains ***Dalí*** and not ***Dal�***.