### PR TITLE
Increase FAB size

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -50,12 +50,12 @@
                 android:layout_height="wrap_content"
                 android:layout_alignParentBottom="true"
                 android:layout_alignParentRight="true"
-                android:layout_gravity="bottom|right"
-                android:layout_margin="8dp"
+                android:layout_gravity="bottom|right|end"
+                android:layout_margin="16dp"
                 app:elevation="4dp"
                 app:borderWidth="0dp"
                 android:src="@mipmap/ic_shuffle"
-                app:fabSize="mini" />
+                app:fabSize="normal" />
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
     </RelativeLayout>

--- a/app/src/main/res/layout/whatif_pager.xml
+++ b/app/src/main/res/layout/whatif_pager.xml
@@ -33,10 +33,10 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|right"
         android:elevation="4dp"
-        app:borderWidth="0dp"
         app:layout_anchorGravity="bottom|right|end"
         android:src="@mipmap/ic_shuffle"
         app:layout_behavior="de.tap.easy_xkcd.misc.ScrollAwareFABBehavior"
+        app:fabSize="normal"
         android:layout_margin="16dp" />
 
 


### PR DESCRIPTION
Use a regular FAB instead of a mini one and increase the margin to 16dp,
according to https://material.io/components/buttons-floating-action-button#specs

Closes #172