### PR TITLE
Use Dependabot to update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: gradle
+  directory: "/"
+  schedule:
+    interval: daily


### PR DESCRIPTION
I'm using the old Dependabot App in another repo and I'm quite happy with it. It was acquired by GitHub, so it's now available as GitHub feature: https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/