### PR TITLE
Use switches instead of checkboxes in preferences

### DIFF
--- a/app/src/main/res/xml/pref_advanced.xml
+++ b/app/src/main/res/xml/pref_advanced.xml
@@ -9,13 +9,13 @@
         android:defaultValue="default"
         />
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="true"
         android:key="pref_large"
         android:summary="@string/pref_large_sum"
         android:title="@string/pref_large" />
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="true"
         android:key="pref_update_mobile"
         android:title="@string/pref_update_mobile"

--- a/app/src/main/res/xml/pref_alt_sharing.xml
+++ b/app/src/main/res/xml/pref_alt_sharing.xml
@@ -28,17 +28,17 @@
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/pref_share_title">
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="false"
             android:key="pref_share"
             android:summary="@string/pref_share_sum"
             android:title="@string/pref_share" />
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="false"
             android:key="pref_mobile"
             android:summary="@string/pref_mobile_sum"
             android:title="@string/pref_mobile" />
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="false"
             android:key="pref_include_link"
             android:title="@string/pref_share_link"

--- a/app/src/main/res/xml/pref_appearance.xml
+++ b/app/src/main/res/xml/pref_appearance.xml
@@ -12,12 +12,12 @@
         android:persistent="false"
         />
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:key="pref_navbar"
         android:title="@string/pref_navbar"
         android:defaultValue="true" />
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="true"
         android:key="pref_subtitle"
         android:summary="@string/pref_subtitle_sum"
@@ -32,12 +32,12 @@
         android:entryValues="@array/random_values"
         android:defaultValue="@array/random_default" />
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="false"
         android:key="pref_hide_donate"
         android:title="@string/pref_hide_donate" />
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="false"
         android:key="pref_fab_left"
         android:summary="@string/pref_fab_left_hint"

--- a/app/src/main/res/xml/pref_behavior.xml
+++ b/app/src/main/res/xml/pref_behavior.xml
@@ -1,41 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="true"
         android:key="pref_fullscreen_enabled"
         android:summary="@string/pref_fullscreen_enabled_sum"
         android:title="@string/pref_fullscreen_enabled" />
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="false"
         android:key="pref_doubletap"
         android:summary="@string/pref_doubletap_sum"
         android:title="@string/pref_doubletap" />
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="false"
         android:key="pref_overview_default"
         android:title="@string/pref_overview_default"
         android:summary="@string/pref_overview_default_sum" />
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="true"
         android:key="pref_default_zoom"
         android:title="@string/pref_default_zoom"
         android:summary="@string/pref_default_zoom_sum" />
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="true"
         android:key="pref_zoom_scroll"
         android:dependency="pref_default_zoom"
         android:title="@string/pref_zoom_scroll" />
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="true"
         android:key="pref_nav_swipe"
         android:title="@string/pref_nav_swipe" />
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="true"
         android:key="pref_custom_tabs"
         android:title="@string/pref_chrome_custom_tabs" />

--- a/app/src/main/res/xml/pref_night.xml
+++ b/app/src/main/res/xml/pref_night.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <CheckBoxPreference
+    <SwitchPreference
         android:key="pref_night"
         android:title="@string/pref_night"
         android:defaultValue="false" />
@@ -12,26 +12,26 @@
         android:persistent="false"
         />
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:key="pref_amoled"
         android:title="@string/pref_amoled"
         android:summary="@string/pref_amoled_sum"
         android:defaultValue="false"
         android:dependency="pref_night" />
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:key="pref_invert"
         android:title="@string/pref_invert"
         android:defaultValue="true"
         android:dependency="pref_night" />
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:key="pref_detect_color"
         android:title="@string/pref_detect_color"
         android:defaultValue="true"
         android:dependency="pref_invert" />
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:title="@string/pref_auto_night"
         android:key="pref_auto_night"
         android:dependency="pref_night"/>

--- a/app/src/main/res/xml/pref_offline_notifications.xml
+++ b/app/src/main/res/xml/pref_offline_notifications.xml
@@ -8,12 +8,12 @@
         android:defaultValue="0"
         android:summary="@string/pref_notifications_sum"
         />
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="false"
         android:key="pref_offline"
         android:summary="@string/pref_offline_sum"
         android:title="@string/pref_offline" />
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="false"
         android:key="pref_offline_whatif"
         android:summary="@string/pref_offline_whatif_sum"

--- a/app/src/main/res/xml/pref_widgets.xml
+++ b/app/src/main/res/xml/pref_widgets.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="true"
         android:key="widget_alt"
         android:title="@string/pref_widget_alt" />
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="true"
         android:key="widget_comicNumber"
         android:title="@string/pref_widget_comicNumber" />


### PR DESCRIPTION
SwitchPreference and CheckBoxPreference both inherit from
TwoStatePreference and share most of their code, so no
further code changes are required.

Closes #200