### PR TITLE
Add FastScrollPopup to compact cards overview

### DIFF
--- a/app/src/main/java/de/tap/easy_xkcd/fragments/overview/OverviewRecyclerBaseFragment.java
+++ b/app/src/main/java/de/tap/easy_xkcd/fragments/overview/OverviewRecyclerBaseFragment.java
@@ -21,6 +21,8 @@ package de.tap.easy_xkcd.fragments.overview;
 import android.content.DialogInterface;
 import android.graphics.Bitmap;
 import android.graphics.Color;
+
+import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.AlertDialog;
 import androidx.cardview.widget.CardView;
@@ -57,7 +59,7 @@ public abstract class OverviewRecyclerBaseFragment extends OverviewBaseFragment 
     protected RVAdapter rvAdapter;
     protected FastScrollRecyclerView rv;
 
-    public abstract class RVAdapter extends RecyclerView.Adapter<RVAdapter.ComicViewHolder> {
+    public abstract class RVAdapter extends RecyclerView.Adapter<RVAdapter.ComicViewHolder> implements FastScrollRecyclerView.SectionedAdapter {
 
         @Override
         public int getItemCount() {
@@ -150,6 +152,12 @@ public abstract class OverviewRecyclerBaseFragment extends OverviewBaseFragment 
         @Override
         public void onAttachedToRecyclerView(RecyclerView recyclerView) {
             super.onAttachedToRecyclerView(recyclerView);
+        }
+
+        @NonNull
+        @Override
+        public String getSectionName(int position) {
+            return String.valueOf((comics.size() - position) / 10 * 10);
         }
 
         public class ComicViewHolder extends RecyclerView.ViewHolder {

--- a/app/src/main/res/layout/recycler_layout.xml
+++ b/app/src/main/res/layout/recycler_layout.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context="de.tap.easy_xkcd.Activities.SearchResultsActivity"
-    android:orientation="vertical">
-
-    <com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:id="@+id/rv"
-        android:layout_below="@id/toolbar"
-        android:scrollbars="vertical"
-        />
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        tools:context="de.tap.easy_xkcd.Activities.SearchResultsActivity"
+        android:orientation="vertical">
+
+    <com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:fastScrollPopupBgColor="?colorAccent"
+            android:id="@+id/rv"
+            android:layout_below="@id/toolbar"
+            android:scrollbars="vertical" />
 
 </RelativeLayout>


### PR DESCRIPTION
I rounded the shown number to multiples of 10, because getSectionName() is called for any item that is currently visible. Sometimes for the first visible card, but sometimes for one in the middle. Rounding mitigates this.