### PR TITLE
Alt text fix: escape HTML, fixes #176

### DIFF
--- a/app/src/main/java/de/tap/easy_xkcd/fragments/comics/ComicFragment.java
+++ b/app/src/main/java/de/tap/easy_xkcd/fragments/comics/ComicFragment.java
@@ -213,7 +213,7 @@ public abstract class ComicFragment extends Fragment {
             RealmComic comic = getRealmComic(position); //TODO check if comic is null
 
             try {
-                tvAlt.setText(Html.fromHtml(comic.getAltText()));
+                tvAlt.setText(Html.fromHtml(Html.escapeHtml(comic.getAltText())));
                 tvTitle.setText((prefHelper.subtitleEnabled() ? "" : comic.getComicNumber() + ": ") + Html.fromHtml(RealmComic.getInteractiveTitle(comic, getActivity())));
                 pvComic.setTransitionName("im" + comic.getComicNumber());
                 tvTitle.setTransitionName(String.valueOf(comic.getComicNumber()));


### PR DESCRIPTION
In order to fix issue #176's bug with comic \#1965, I wrapped a single call to `getAltText()` with `Html.escapeHtml()`. This doesn't cover _all_ uses of the alt text, but it fixes the long tap TextView glitch.

Instead of `Html.escapeHtml()`, you may want to use `TextUtils.htmlEncode()` depending on how the app handles symbols.