### PR TITLE
Offline optimization: skip preexisting files when downloading.

### DIFF
--- a/app/src/main/java/de/tap/easy_xkcd/database/RealmComic.java
+++ b/app/src/main/java/de/tap/easy_xkcd/database/RealmComic.java
@@ -245,8 +245,16 @@ public class RealmComic extends RealmObject {
             if (!dir.exists()) {
                 dir.mkdirs();
             }
-            try (FileOutputStream fos = new FileOutputStream(sdCard.getAbsolutePath() + RealmComic.OFFLINE_PATH + "/" + comicFileName)) {
-                fos.write(response.body().bytes());
+
+            String comicFilePath = sdCard.getAbsolutePath() + RealmComic.OFFLINE_PATH + "/" + comicFileName;
+            File comicFile = new File(comicFilePath);
+
+            if (!comicFile.exists() || prefHelper.replaceOffline()) {
+                try (FileOutputStream fos = new FileOutputStream(sdCard.getAbsolutePath() + RealmComic.OFFLINE_PATH + "/" + comicFileName)) {
+                    fos.write(response.body().bytes());
+                }
+            } else {
+                Timber.d("Skipping saving existing comic.");
             }
         } catch (Exception e) {
             Timber.e("Error at comic %d: Saving to external storage failed: %s", comicNumber, e.getMessage());

--- a/app/src/main/java/de/tap/easy_xkcd/utils/PrefHelper.java
+++ b/app/src/main/java/de/tap/easy_xkcd/utils/PrefHelper.java
@@ -52,6 +52,7 @@ public class PrefHelper {
     private int randIndex = 0;
 
     private static final String FULL_OFFLINE = "pref_offline";
+    private static final String REPLACE_OFFLINE = "pref_replace_offline";
     private static final String COMIC_TITLES = "comic_titles";
     private static final String COMIC_TRANS = "comic_trans";
     private static final String COMIC_URLS = "comic_urls";
@@ -134,6 +135,12 @@ public class PrefHelper {
 
     public void setFullOffline(boolean value) {
         prefs.edit().putBoolean(FULL_OFFLINE, value).apply();
+    }
+
+    public boolean replaceOffline() { return prefs.getBoolean(REPLACE_OFFLINE, true); }
+
+    public void setReplaceOffline(boolean value) {
+        prefs.edit().putBoolean(REPLACE_OFFLINE, value).apply();
     }
 
     public boolean transcriptsFixed() {

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -209,6 +209,8 @@
     <string name="pref_large_sum">Načítat velké obrázky pokud jsou dostupné (např. #657). Může snížit výkon na starších přístrojích</string>
     <string name="pref_offline">Offline mód</string>
     <string name="pref_offline_sum">Stáhnout všechny komixy do externího úložiště Nové komixy budou přidány automaticky. Zabere až ~150MB.</string>
+    <string name="pref_replace_offline">Nahradit stahování</string>
+    <string name="pref_replace_offline_sum">Při povolení režimu offline stáhněte a nahraďte stávající komiksové soubory.</string>
     <string name="pref_offline_whatif">&quot;What if?&quot; offline mód</string>
     <string name="pref_mobile">Sdílet mobilní odkazy</string>
     <string name="pref_mobile_sum">Sdílet m.xkcd.com odkazy místo xkcd.com</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -192,6 +192,8 @@
     <string name="pref_large_sum">Lade große Bilder wenn verfügbar (z.B. #657). Kann die Performance auf älteren Geräten beeinträchtigen </string>
     <string name="pref_offline">Offline Modus </string>
     <string name="pref_offline_sum">Sichert alle Comics im externen Speicher. Neue Comics werden automatisch hinzugefügt. Belegt ~150MB Speicher</string>
+    <string name="pref_replace_offline">Ersetzen Sie Downloads </string>
+    <string name="pref_replace_offline_sum">Wenn Sie den Offline-Modus aktivieren, laden Sie vorhandene Comic-Dateien herunter und ersetzen Sie sie.</string>
     <string name="loading_offline_97">Du hättest dein Gesicht sehen sollen!</string>
     <string name="delete_offline">Löscht Comics&#8230;</string>
     <string name="delete_offline_dialog">Willst du wirklich den Offline Modus deaktivieren? Alle Bilder (außer Favoriten) werden gelöscht.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -209,6 +209,8 @@
     <string name="pref_large_sum">Cargar las imágenes grandes (como la #657). Es posible que el rendimiento disminuya en dispositivos más viejos </string>
     <string name="pref_offline">Modo sin conexión</string>
     <string name="pref_offline_sum">Descargar todos los cómics en la memoria externa. Nuevos cómics serán añadidos automáticamente. Toma alrededor de ~150MB.</string>
+    <string name="pref_replace_offline">Reemplazar descargas</string>
+    <string name="pref_replace_offline_sum">Al habilitar el modo sin conexión, descargue y reemplace los archivos de cómics existentes.</string>
     <string name="pref_offline_whatif">Modo sin conexión de "What if?"</string>
     <string name="pref_mobile">Compartir enlaces de móvil</string>
     <string name="pref_mobile_sum">Compartir enlaces m.xkcd.com en vez de xkcd.com</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -304,6 +304,8 @@
     <string name="pref_large_sum">Carrega imagens grandes, se disponível (p.ex., #657). Pode reduzir o desempenho em dispositivos antigos </string>
     <string name="pref_offline">Modo offline</string>
     <string name="pref_offline_sum">Baixa todos os quadrinhos para um armazenamento externo. Novos quadrinhos serão adicionados automaticamente. Ocupa cerca de ~150MB.</string>
+    <string name="pref_replace_offline">Substituir quadrinhos baixados</string>
+    <string name="pref_replace_offline_sum">Ao habilitar o modo offline, baixe e substitua os arquivos de quadrinhos existentes.</string>
     <string name="pref_offline_whatif">Modo offline do "What if?"</string>
     <string name="pref_offline_whatif_sum" translatable="false">~20 MB</string>
     <string name="pref_mobile">Compartilhar links móveis</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -208,6 +208,8 @@
     <string name="pref_large_sum">Учитавање великих слика ако их има (нпр. #657). Може да утиче на перформансе на старијим уређајима</string>
     <string name="pref_offline">Режим ван везе</string>
     <string name="pref_offline_sum">Преузимање свих стрипова на унутрашње складиште. Нови стрипови ће бити додавани аутоматски</string>
+    <string name="pref_replace_offline">Замените преузимања</string>
+    <string name="pref_replace_offline_sum">Када омогућавате офлајн режим, преузмите и замените постојеће стрип датотеке.</string>
     <string name="pref_offline_whatif">Режим ван везе за "What if?"</string>
     <string name="pref_mobile">Дели мобилне везе</string>
     <string name="pref_mobile_sum">Дељење m.xkcd.com уместо xkcd.com</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -133,6 +133,7 @@
 <string name="pref_random_title" modified="true">在……隐藏 FAB</string>
 <string name="no_connection" modified="true">无连接……</string>
 <string name="pref_offline" modified="true">离线模式</string>
+<string name="pref_replace_offline" modified="true">替换下载</string>
 <string name="loading_offline" modified="true">正在下载漫画……</string>
 <string name="action_browser" modified="true">在浏览器中打开</string>
 <string name="whatif_overview" modified="true">概览</string>
@@ -160,6 +161,7 @@
 <string name="add_bookmark" modified="true">添加书签</string>
 <string name="pref_repair_sum" modified="true">If you see some blank comics or encounter crashes, this might be the solution</string>
 <string name="pref_offline_sum" modified="true">将所有漫画下载至外部存储。新漫画将会自动添加。占用约 150MB。</string>
+<string name="pref_replace_offline_sum" modified="true">启用脱机模式时，下载并替换现有的漫画文件。</string>
 <string name="pref_alt_activation_sum" modified="true">长按或单击</string>
 <string name="favorites_cleared" modified="true">已清除收藏</string>
 <string name="snackbar_survey_oc" modified="true">做一个问卷调查</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -324,6 +324,8 @@
     <string name="pref_large_sum">Load large images if available (e.g. #657). May decrease performance on older devices </string>
     <string name="pref_offline">Offline mode</string>
     <string name="pref_offline_sum">Download all comics to external storage. New comics will be added automatically. Takes up ~150MB.</string>
+    <string name="pref_replace_offline">Replace downloaded comics</string>
+    <string name="pref_replace_offline_sum">When enabling offline mode, redownload and replace existing comic files.</string>
     <string name="pref_offline_whatif">"What if?" offline mode</string>
     <string name="pref_offline_whatif_sum" translatable="false">~20 MB</string>
     <string name="pref_mobile">Share mobile links</string>

--- a/app/src/main/res/xml/pref_offline_notifications.xml
+++ b/app/src/main/res/xml/pref_offline_notifications.xml
@@ -14,6 +14,11 @@
         android:title="@string/pref_offline" />
     <SwitchPreference
         android:defaultValue="false"
+        android:key="pref_replace_offline"
+        android:summary="@string/pref_replace_offline_sum"
+        android:title="@string/pref_replace_offline" />
+    <SwitchPreference
+        android:defaultValue="false"
         android:key="pref_offline_whatif"
         android:summary="@string/pref_offline_whatif_sum"
         android:title="@string/pref_offline_whatif" />


### PR DESCRIPTION
This fixes #228 and includes a new preference called "Replace downloaded comics," which defaults to false and allows an override to force redownloading all comics when enabling offline mode. This functionality is primarily enabled in `RealmComic.saveOfflineBitmap()`.

I had some trouble localizing the preference for some languages, chiefly Chinese—Google Translate has notoriously poor translation for that language and I am not familiar with the script at all. I am able to more-or-less verify the integrity of some of the other languages and Spanish and Portuguese are probably alright.