### PR TITLE
Store and show comic date

### DIFF
--- a/app/src/main/java/de/tap/easy_xkcd/database/RealmComic.java
+++ b/app/src/main/java/de/tap/easy_xkcd/database/RealmComic.java
@@ -56,6 +56,8 @@ public class RealmComic extends RealmObject {
     private String url;
     private String altText;
     private String preview;
+    /** Stores the ISO 8601 upload date of the comic **/
+    private String date;
 
     public int getComicNumber() {
         return comicNumber;
@@ -130,6 +132,18 @@ public class RealmComic extends RealmObject {
         this.altText = altText;
     }
 
+    public String getDate() {
+        return this.date;
+    }
+
+    public void setDate(String date) {
+        this.date = date;
+    }
+
+    public void setDate(int year, int month, int day) {
+        this.date = String.format("%04d-%02d-%02d", year, month, day);
+    }
+
     public static boolean isInteractiveComic(int number, Context context) {
         return Arrays.binarySearch(context.getResources().getIntArray(R.array.interactive_comics), number) >= 0;
     }
@@ -164,6 +178,8 @@ public class RealmComic extends RealmObject {
         RealmComic realmComic = new RealmComic();
 
         String title = "", altText = "", url = "", transcript = "";
+        // Unix epoch for null date
+        int year = 1970, month = 1, day = 1;
         if (comicNumber == 404) {
             title = "404";
             altText = "404";
@@ -183,6 +199,9 @@ public class RealmComic extends RealmObject {
 
                 altText = new String(json.getString("alt").getBytes(UTF_8));
                 transcript = json.getString("transcript");
+                year = json.getInt("year");
+                month = json.getInt("month");
+                day = json.getInt("day");
 
                 // some image and title fixes
                 switch (comicNumber) {
@@ -199,6 +218,7 @@ public class RealmComic extends RealmObject {
         realmComic.setAltText(altText);
         realmComic.setUrl(url);
         realmComic.setTranscript(transcript);
+        realmComic.setDate(year, month, day);
 
         return realmComic;
     }

--- a/app/src/main/java/de/tap/easy_xkcd/fragments/comics/ComicFragment.java
+++ b/app/src/main/java/de/tap/easy_xkcd/fragments/comics/ComicFragment.java
@@ -209,12 +209,14 @@ public abstract class ComicFragment extends Fragment {
             final PhotoView pvComic = itemView.findViewById(R.id.ivComic);
             final TextView tvAlt = itemView.findViewById(R.id.tvAlt);
             final TextView tvTitle = itemView.findViewById(R.id.tvTitle);
+            final TextView tvDate = itemView.findViewById(R.id.tvDate);
 
             RealmComic comic = getRealmComic(position); //TODO check if comic is null
 
             try {
                 tvAlt.setText(Html.fromHtml(Html.escapeHtml(comic.getAltText())));
                 tvTitle.setText((prefHelper.subtitleEnabled() ? "" : comic.getComicNumber() + ": ") + Html.fromHtml(RealmComic.getInteractiveTitle(comic, getActivity())));
+                tvDate.setText(comic.getDate());
                 pvComic.setTransitionName("im" + comic.getComicNumber());
                 tvTitle.setTransitionName(String.valueOf(comic.getComicNumber()));
 

--- a/app/src/main/res/layout/pager_item.xml
+++ b/app/src/main/res/layout/pager_item.xml
@@ -33,6 +33,15 @@
     </TextView>
 
     <TextView
+        android:id="@+id/tvDate"
+        android:gravity="top|center"
+        android:layout_below="@id/tvTitle"
+        android:layout_height="wrap_content"
+        android:layout_width="fill_parent"
+        android:textSize="@dimen/text_body1" >
+    </TextView>
+
+    <TextView
         android:id="@+id/tvAlt"
         android:layout_alignParentBottom="true"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="loading_offline_97">You should have seen your face!</string>
     <string name="delete_offline">Deleting Comics&#8230;</string>
     <string name="delete_offline_articles">Deleting articles&#8230;</string>
+    <string name="date_error">Date Error</string>
 
     <string name="snackbar_remove">Comic removed from favorites</string>
     <string name="snackbar_add">Comic added to favorites</string>


### PR DESCRIPTION
Stores the publication date alongside other comic metadata.

Right now the date just displays in the raw ISO 8601 as a subtitle for the comic, but localized formatting and other tweaks could be implemented. I haven't worked with Android UI in a while though, so I didn't want to risk making too many changes in that respect.

<img src="https://user-images.githubusercontent.com/4533896/135795637-7e189241-619f-42e6-8666-3c05fb0926bb.png" alt="Screenshot as of commit e403737" height="480" />