### PR TITLE
fix: add new line before share image URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.2.1
+
+- Sharing: Fix missing new line between title and URL (thanks to @FineFindus)
+
 ## 8.2
 
 - Add support for themed icons (thanks to @thgoebel)

--- a/app/src/main/java/de/tap/easy_xkcd/comicBrowsing/ComicBrowserBaseFragment.kt
+++ b/app/src/main/java/de/tap/easy_xkcd/comicBrowsing/ComicBrowserBaseFragment.kt
@@ -447,7 +447,7 @@ abstract class ComicBrowserBaseFragment : Fragment() {
                 extraText += "\n" + comic.altText
             }
             if (settings.includeLinkWhenSharing) {
-                extraText += "https://${if (settings.shareMobile) "m." else ""}xkcd.com/${comic.number}/"
+                extraText += "\n" + "https://${if (settings.shareMobile) "m." else ""}xkcd.com/${comic.number}/"
             }
             share.putExtra(Intent.EXTRA_TEXT, extraText)
 


### PR DESCRIPTION
Fixes an issue where the title and URL were not separated when sharing the image (without alt text).
For example, it would be shared as `Helium Reservehttps://xkcd.com/2766/` instead of `Helium Reserve https://xkcd.com/2766/`.
This pull request fixes this by prepending a new line to the URL.