### PR TITLE
fix: implement mark all as read und unread

### DIFF
--- a/app/src/main/java/de/tap/easy_xkcd/comicOverview/ComicOverviewFragment.kt
+++ b/app/src/main/java/de/tap/easy_xkcd/comicOverview/ComicOverviewFragment.kt
@@ -267,6 +267,10 @@ class ComicOverviewFragment : Fragment() {
             model.toggleOnlyFavorites()
             true
         }
+        R.id.action_all_read -> {
+            model.setAllRead(true)
+            true
+        }
         R.id.action_hide_read -> {
             model.toggleHideRead()
             true

--- a/app/src/main/java/de/tap/easy_xkcd/comicOverview/ComicOverviewFragment.kt
+++ b/app/src/main/java/de/tap/easy_xkcd/comicOverview/ComicOverviewFragment.kt
@@ -267,6 +267,10 @@ class ComicOverviewFragment : Fragment() {
             model.toggleOnlyFavorites()
             true
         }
+        R.id.action_unread -> {
+            model.setAllRead(false)
+            true
+        }
         R.id.action_all_read -> {
             model.setAllRead(true)
             true

--- a/app/src/main/java/de/tap/easy_xkcd/comicOverview/ComicOverviewViewModel.kt
+++ b/app/src/main/java/de/tap/easy_xkcd/comicOverview/ComicOverviewViewModel.kt
@@ -80,6 +80,11 @@ class ComicOverviewViewModel @Inject constructor(
         repository.setRead(number, read)
     }
 
+    fun setAllRead(read: Boolean) = viewModelScope.launch {
+            repository.setAllRead(read)
+    }
+
+
     fun toggleOnlyFavorites() {
         sharedPrefs.showOnlyFavsInOverview = !sharedPrefs.showOnlyFavsInOverview
         _onlyFavorites.value = sharedPrefs.showOnlyFavsInOverview

--- a/app/src/main/java/de/tap/easy_xkcd/database/comics/ComicDao.kt
+++ b/app/src/main/java/de/tap/easy_xkcd/database/comics/ComicDao.kt
@@ -29,6 +29,9 @@ interface ComicDao {
     @Query("UPDATE Comic SET read=:read WHERE number=:number")
     suspend fun setRead(number: Int, read: Boolean)
 
+    @Query("UPDATE Comic SET read=:read")
+    suspend fun setAllRead(read: Boolean)
+
     @Query("SELECT * FROM Comic WHERE favorite")
     fun getFavorites() : Flow<List<Comic>>
 

--- a/app/src/main/java/de/tap/easy_xkcd/database/comics/ComicRepository.kt
+++ b/app/src/main/java/de/tap/easy_xkcd/database/comics/ComicRepository.kt
@@ -83,6 +83,7 @@ interface ComicRepository {
     suspend fun removeAllFavorites()
 
     suspend fun setRead(number: Int, read: Boolean)
+    suspend fun setAllRead(read: Boolean)
 
     suspend fun setFavorite(number: Int, favorite: Boolean)
 
@@ -173,6 +174,11 @@ class ComicRepositoryImpl @Inject constructor(
             comicDao.setRead(number, read)
         }
     }
+
+    override suspend fun setAllRead(read: Boolean) {
+        comicDao.setAllRead(read)
+    }
+
 
     override suspend fun setFavorite(number: Int, favorite: Boolean) {
         if (favorite) {


### PR DESCRIPTION
Closes #310 by implementing an action when clicking the `mark all as read` and `mark all as unread` options in the comic overview. These seem to have been lost when rewriting the fragment in Kotlin, as I couldn't find any implementation needed for their implementation.