### PR TITLE
fix: use different inversion for night mode

### DIFF
--- a/app/src/main/java/de/tap/easy_xkcd/ComicBaseAdapter.kt
+++ b/app/src/main/java/de/tap/easy_xkcd/ComicBaseAdapter.kt
@@ -109,7 +109,7 @@ abstract class ComicBaseAdapter<ViewHolder: ComicViewHolder>(
         holder.title.text = prefix + Html.fromHtml(Comic.getInteractiveTitle(comic, context))
 
         if (appTheme.invertColors) {
-            holder.image?.colorFilter = AppTheme.negativeColorFilter
+            holder.image?.colorFilter = appTheme.colorFilter()
         }
 
         val gifId = when (comic.number) {

--- a/app/src/main/java/de/tap/easy_xkcd/utils/AppTheme.kt
+++ b/app/src/main/java/de/tap/easy_xkcd/utils/AppTheme.kt
@@ -37,13 +37,25 @@ class AppTheme(
         private const val AUTO_NIGHT_END_HOUR = "pref_auto_night_end_hour"
         private const val INVERT_COLORS = "pref_invert"
 
-        val negativeColorFilter = ColorMatrixColorFilter(floatArrayOf(
-            -1.0f, 0f, 0f, 0f, 255f, //red
-            0f, -1.0f, 0f, 0f, 255f, //green
-            0f, 0f, -1.0f, 0f, 255f, //blue
-            0f, 0f, 0f, 1.0f, 0f //alpha
-        ))
     }
+
+    fun colorFilter(): ColorMatrixColorFilter = if (amoledThemeEnabled())
+        ColorMatrixColorFilter(
+            floatArrayOf(
+                -1.0f, 0f, 0f, 0f, 255f, //red
+                0f, -1.0f, 0f, 0f, 255f, //green
+                0f, 0f, -1.0f, 0f, 255f, //blue
+                0f, 0f, 0f, 1.0f, 0f //alpha
+            )
+        ) else
+        ColorMatrixColorFilter(
+            floatArrayOf(
+                -0.82f, 0f, 0f, 0f, 255f,  //red
+                0f, -0.82f, 0f, 0f, 255f,  //green
+                0f, 0f, -0.82f, 0f, 255f,  //blue
+                0f, 0f, 0f, 1.0f, 0f //alpha
+            )
+        )
 
     private val detectColors by ReadOnlyPref(prefs, DETECT_COLOR, true)
     fun bitmapContainsColor(bitmap: Bitmap, comicNumber: Int): Boolean {

--- a/app/src/main/java/de/tap/easy_xkcd/whatIfOverview/OverviewAdapter.kt
+++ b/app/src/main/java/de/tap/easy_xkcd/whatIfOverview/OverviewAdapter.kt
@@ -106,7 +106,7 @@ class OverviewAdapter constructor(
                 )
             }
             if (appTheme.invertColors || appTheme.amoledThemeEnabled())
-                thumbnail.colorFilter = AppTheme.negativeColorFilter
+                thumbnail.colorFilter = appTheme.colorFilter()
 
             itemView.setOnClickListener { itemClickedCallback(articles[adapterPosition]) }
             itemView.setOnLongClickListener { itemLongClickedCallback(articles[adapterPosition]) }


### PR DESCRIPTION
Closes #261, by using a different `ColorMatrixColorFilter` which uses the correct background color.

![Example Screenshot of the comic with the same background color as the background](https://user-images.githubusercontent.com/63370021/235302622-9ad9260e-4f30-4a6d-be5a-6d88753b4ef8.png)