### PR TITLE
fix: comic 2622 coloring

### DIFF
--- a/app/src/main/java/de/tap/easy_xkcd/utils/AppTheme.kt
+++ b/app/src/main/java/de/tap/easy_xkcd/utils/AppTheme.kt
@@ -50,7 +50,7 @@ class AppTheme(
         //TODO Add more special cases here
         //these are special case, which contains color and should not be recolored
         // see https://github.com/tom-anders/Easy_xkcd/issues/116 for an example
-        val specialCases = arrayOf(1913, 1551, 2018)
+        val specialCases = arrayOf(1551, 1913, 2018, 2622)
         if (specialCases.contains(comicNumber))
             return true
 

--- a/app/src/main/java/de/tap/easy_xkcd/utils/AppTheme.kt
+++ b/app/src/main/java/de/tap/easy_xkcd/utils/AppTheme.kt
@@ -48,11 +48,12 @@ class AppTheme(
     private val detectColors by ReadOnlyPref(prefs, DETECT_COLOR, true)
     fun bitmapContainsColor(bitmap: Bitmap, comicNumber: Int): Boolean {
         //TODO Add more special cases here
-        if (comicNumber == 1913) //https://github.com/tom-anders/Easy_xkcd/issues/116
+        //these are special case, which contains color and should not be recolored
+        // see https://github.com/tom-anders/Easy_xkcd/issues/116 for an example
+        val specialCases = arrayOf(1913, 1551, 2018)
+        if (specialCases.contains(comicNumber))
             return true
-        if (comicNumber == 1551) return true
-        if (comicNumber == 2018) //This one doesn't work w/o the yellow color
-            return true
+
         return if (detectColors) try {
             Palette.from(bitmap).generate().vibrantSwatch != null
         } catch (e: Exception) {


### PR DESCRIPTION
Partially fixing #305, by adding comic 2622 as a special case.

| Before                                                                                                           	| After                                                                                                           	|
|------------------------------------------------------------------------------------------------------------------	|-----------------------------------------------------------------------------------------------------------------	|
| ![Before](https://user-images.githubusercontent.com/63370021/235317291-b516c8be-e85e-489f-a285-fdcb8974a1bc.png) 	| ![After](https://user-images.githubusercontent.com/63370021/235317292-6a24c36c-c6a5-434d-9a2f-2a198ccfc088.png) 	|

Of course, this does not solve the general problem of some comics being incorrectly inverted. I think one solution might be to check each pixel color, but I'm not sure whether that would perform well enough.  Should I open a new issue about possible solutions? 