### PR TITLE
fix: invert detect_color toggle

### DIFF
--- a/app/src/main/java/de/tap/easy_xkcd/settings/NightPreferences.kt
+++ b/app/src/main/java/de/tap/easy_xkcd/settings/NightPreferences.kt
@@ -44,7 +44,7 @@ class NightFragment: BasePreferenceFragment() {
             true
         }
 
-        findPreference<Preference>("pref_detect_color")?.setOnPreferenceClickListener {
+        findPreference<Preference>("pref_invert_color")?.setOnPreferenceClickListener {
             activity?.setResult(BaseSettingsActivity.RESULT_RESTART_MAIN)
             true
         }

--- a/app/src/main/java/de/tap/easy_xkcd/utils/AppTheme.kt
+++ b/app/src/main/java/de/tap/easy_xkcd/utils/AppTheme.kt
@@ -29,13 +29,13 @@ class AppTheme(
         private const val NIGHT_THEME = "pref_night"
         private const val NIGHT_SYSTEM = "pref_night_system"
         private const val AMOLED_NIGHT = "pref_amoled"
-        private const val DETECT_COLOR = "pref_detect_color"
-
         private const val AUTO_NIGHT_START_MIN = "pref_auto_night_start_min"
+
         private const val AUTO_NIGHT_START_HOUR = "pref_auto_night_start_hour"
         private const val AUTO_NIGHT_END_MIN = "pref_auto_night_end_min"
         private const val AUTO_NIGHT_END_HOUR = "pref_auto_night_end_hour"
         private const val INVERT_COLORS = "pref_invert"
+        private const val INVERT_COLOR_IMG = "pref_invert_color"
 
     }
 
@@ -57,7 +57,7 @@ class AppTheme(
             )
         )
 
-    private val detectColors by ReadOnlyPref(prefs, DETECT_COLOR, true)
+    private val invertColorImg by ReadOnlyPref(prefs, INVERT_COLOR_IMG, true)
     fun bitmapContainsColor(bitmap: Bitmap, comicNumber: Int): Boolean {
         //TODO Add more special cases here
         //these are special case, which contains color and should not be recolored
@@ -66,10 +66,12 @@ class AppTheme(
         if (specialCases.contains(comicNumber))
             return true
 
-        return if (detectColors) try {
-            Palette.from(bitmap).generate().vibrantSwatch != null
-        } catch (e: Exception) {
-            false
+        return if (!invertColorImg) {
+            try {
+                Palette.from(bitmap).generate().vibrantSwatch != null
+            } catch (e: Exception) {
+                false
+            }
         } else false
     }
 

--- a/app/src/main/res/xml/pref_night.xml
+++ b/app/src/main/res/xml/pref_night.xml
@@ -27,7 +27,7 @@
         android:defaultValue="true" />
 
     <SwitchPreference
-        android:key="pref_detect_color"
+        android:key="pref_invert_color"
         android:title="@string/pref_detect_color"
         android:defaultValue="true"
         android:dependency="pref_invert" />


### PR DESCRIPTION
Fixes #334, by inverting the `detect_color` pref. It also renames it to `invert_color_img` to better convey the usage.