### PR TITLE
Update What If Next and Previous Action Titles

### DIFF
--- a/app/src/main/res/menu/menu_what_if.xml
+++ b/app/src/main/res/menu/menu_what_if.xml
@@ -23,12 +23,12 @@
     </group>
     <group android:id="@+id/groupWhatifNavigation">
         <item android:id="@+id/action_back"
-            android:title="@string/action_share_article"
+            android:title="@string/action_previous_article"
             android:icon="@drawable/ic_outline_navigate_before_24dp"
             app:showAsAction="always" />
 
         <item android:id="@+id/action_next"
-            android:title="@string/action_favorite"
+            android:title="@string/action_next_article"
             app:showAsAction="always"
             android:icon="@drawable/ic_outline_navigate_next_24dp"/>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,8 @@
     <string name="action_swipe">Swipe to navigate</string>
     <string name="action_donate">Donate</string>
     <string name="action_trans">View Transcript</string>
+    <string name="action_next_article">Next Article</string>
+    <string name="action_previous_article">Previous Article</string>
     <string name="action_alt_tip">Tip: You can also view the alt text by long pressing the comic image.</string>
     <string name="what_if_tip">Did you know? Tap an image to view its mouseover text!</string>
     <string name="random_tip">Did you know? Long press the button to get to the previous comic!</string>


### PR DESCRIPTION
### Fix
Update the string references for the next and previous actions in the What If menu from ***Share article*** and ***Add to Favorites*** to ***Next Article*** and ***Previous Article***.  See the screenshots below for illustration.

<details>
<summary>
<h3>Screenshots</h3>
</summary>
<img src="https://github.com/tom-anders/Easy_xkcd/assets/3827611/a3443a7d-8fe9-44b4-b604-8c88e3bed680" alt="Screenshots of What If Next and Previous Action Tooltips Before and After Changes">
</details>

### Test
1. Open What If article other than 1 or 162.
2. Long-press next action in top app bar.
3. Notice ***Next Article*** tooltip is shown.
4. Long-press previous action in top app bar.
5. Notice ***Previous Article*** tooltip is shown.