### PR TITLE
add confirmation to mark all as unread or read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add confirmation to mark all as unread or read
+
 ## 8.5
 
 - Double tapping a comic zooms to where you tapped (instead of simply to the image center)

--- a/app/src/main/java/de/tap/easy_xkcd/comicOverview/ComicOverviewFragment.kt
+++ b/app/src/main/java/de/tap/easy_xkcd/comicOverview/ComicOverviewFragment.kt
@@ -268,11 +268,28 @@ class ComicOverviewFragment : Fragment() {
             true
         }
         R.id.action_unread -> {
-            model.setAllRead(false)
+            AlertDialog.Builder(requireContext()).setTitle(R.string.action_unread)
+                .setMessage(R.string.clear_all_read_confirm)
+                .setPositiveButton(R.string.clear_confirm) { dialogInterface, _ ->
+                    model.setAllRead(false)
+                    dialogInterface.dismiss()
+                }
+                .setNegativeButton(R.string.dialog_cancel) { dialogInterface, _ ->
+                    dialogInterface.dismiss()
+                }.show()
             true
         }
         R.id.action_all_read -> {
-            model.setAllRead(true)
+            AlertDialog.Builder(requireContext()).setTitle(R.string.action_all_read)
+                .setMessage(R.string.clear_all_read_confirm)
+                .setPositiveButton(R.string.clear_confirm) { dialogInterface, _ ->
+                    model.setAllRead(true)
+                    dialogInterface.dismiss()
+                }
+                .setNegativeButton(R.string.dialog_cancel) { dialogInterface, _ ->
+                    dialogInterface.dismiss()
+                }
+                .show()
             true
         }
         R.id.action_hide_read -> {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,8 @@
     <string name="favorites_cleared">Favorites cleared</string>
     <string name="delete_offline_dialog">Are you sure you want to disable Offline Mode? This will delete all saved images(except favorites)</string>
     <string name="delete_offline_whatif_dialog">Are you sure you want to disable Offline Mode? This will delete all saved articles</string>
+    <string name="clear_all_read_confirm">All read progress will be lost.</string>
+    <string name="clear_confirm">Clear</string>
 
     <string name="share_url">Share url with&#8230;</string>
     <string name="share_image">Share image with&#8230;</string>


### PR DESCRIPTION
This is the change we discussed in #342. 

For the confirmation dialog, I used the existing action labels for the title, to avoid adding too many new strings (needing translation for i8n).

Let me know what you think of the dialog phrasing, for both the message and positive button label.   I put the same text for both "read" and "unread" dialogs, as the end result is similar: the user is clearing their history of read/unread items.

I tested this change on my phone, using the "Earliest unread" action to see the true read/unread state.  I wasn't able to see immediate updates in the overview list (compact cards), but I believe that behavior is the same without this update.